### PR TITLE
Endpoint Parameter Registration

### DIFF
--- a/src/Immediate.Apis.Generators/ITypeSymbolExtensions.cs
+++ b/src/Immediate.Apis.Generators/ITypeSymbolExtensions.cs
@@ -84,4 +84,23 @@ internal static class ITypeSymbolExtensions
 				},
 			},
 		};
+
+	public static bool IsEndpointRegistrationOverrideAttribute(this ITypeSymbol? typeSymbol) =>
+		typeSymbol is INamedTypeSymbol
+		{
+			Name: "EndpointRegistrationOverrideAttribute",
+			ContainingNamespace:
+			{
+				Name: "Shared",
+				ContainingNamespace:
+				{
+					Name: "Apis",
+					ContainingNamespace:
+					{
+						Name: "Immediate",
+						ContainingNamespace.IsGlobalNamespace: true,
+					},
+				},
+			},
+		};
 }

--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.Models.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.Models.cs
@@ -5,6 +5,7 @@ public sealed partial class ImmediateApisGenerator
 	private sealed record Method
 	{
 		public required string HttpMethod { get; init; }
+		public required string ParameterAttribute { get; init; }
 		public required string Route { get; init; }
 
 		public required string ClassName { get; init; }

--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
@@ -68,6 +68,10 @@ public sealed partial class ImmediateApisGenerator
 
 		token.ThrowIfCancellationRequested();
 
+		var parameterAttribute = GetParameterAttribute(handleMethod.Parameters[0].Type, httpMethod);
+
+		token.ThrowIfCancellationRequested();
+
 		var useCustomization = HasCustomizationMethod(symbol);
 
 		token.ThrowIfCancellationRequested();
@@ -79,6 +83,7 @@ public sealed partial class ImmediateApisGenerator
 		return new()
 		{
 			HttpMethod = httpMethod,
+			ParameterAttribute = parameterAttribute,
 			Route = route,
 
 			ClassName = className,
@@ -159,4 +164,11 @@ public sealed partial class ImmediateApisGenerator
 					}
 					&& SymbolEqualityComparer.IncludeNullability.Equals(returnInnerType, paramType)
 				);
+
+	private static string GetParameterAttribute(ITypeSymbol parameterType, string httpMethod)
+	{
+		return httpMethod is "MapGet" or "MapDelete"
+			? "AsParameters"
+			: "FromBody";
+	}
 }

--- a/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
+++ b/src/Immediate.Apis.Generators/ImmediateApisGenerator.Transform.cs
@@ -167,6 +167,18 @@ public sealed partial class ImmediateApisGenerator
 
 	private static string GetParameterAttribute(ITypeSymbol parameterType, string httpMethod)
 	{
+		foreach (var a in parameterType.GetAttributes())
+		{
+			if (a.AttributeClass.IsEndpointRegistrationOverrideAttribute())
+			{
+				if (a.ConstructorArguments.Length != 0)
+					return (string)a.ConstructorArguments[0].Value!;
+
+				if (a.NamedArguments.Length != 0)
+					return (string)a.NamedArguments[0].Value.Value!;
+			}
+		}
+
 		return httpMethod is "MapGet" or "MapDelete"
 			? "AsParameters"
 			: "FromBody";

--- a/src/Immediate.Apis.Generators/Templates/Route.sbntxt
+++ b/src/Immediate.Apis.Generators/Templates/Route.sbntxt
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -12,7 +13,7 @@ public static partial class {{ assembly }}RoutesBuilder
 			.{{ method.http_method }}(
 				"{{ method.route }}",
 				async (
-					[AsParameters] {{ method.parameter_type }} parameters,
+					[{{ method.parameter_attribute }}] {{ method.parameter_type }} parameters,
 					[FromServices] {{ method.class_name }}.Handler handler,
 					CancellationToken token
 				) =>

--- a/src/Immediate.Apis.Shared/EndpointRegistration.cs
+++ b/src/Immediate.Apis.Shared/EndpointRegistration.cs
@@ -1,0 +1,54 @@
+namespace Immediate.Apis.Shared;
+
+/// <summary>
+///		Common Registrations for use with <see cref="EndpointRegistrationOverrideAttribute"/>.
+/// </summary>
+public static class EndpointRegistration
+{
+	/// <summary>
+	///		Use <c>[AsParameters]</c> as the registration
+	/// </summary>
+	public const string AsParameters = nameof(AsParameters);
+
+	/// <summary>
+	///		Use <c>[FromBody]</c> as the registration
+	/// </summary>
+	public const string FromBody = nameof(FromBody);
+
+	/// <summary>
+	///		Use <c>[FromForm]</c> as the registration
+	/// </summary>
+	public const string FromForm = nameof(FromForm);
+
+	/// <summary>
+	///		Use <c>[FromHeader]</c> as the registration
+	/// </summary>
+	public const string FromHeader = nameof(FromHeader);
+
+	/// <summary>
+	///		Use <c>[FromQuery]</c> as the registration
+	/// </summary>
+	public const string FromQuery = nameof(FromQuery);
+
+	/// <summary>
+	///		Use <c>[FromRoute]</c> as the registration
+	/// </summary>
+	public const string FromRoute = nameof(FromRoute);
+}
+
+/// <summary>
+///		Specify how the handler parameter should be registered with Minimal Apis
+/// </summary>
+/// <param name="registration">
+///		The desired registration
+/// </param>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class EndpointRegistrationOverrideAttribute(
+	string registration
+) : Attribute
+{
+	/// <summary>
+	///		The desired registration
+	/// </summary>
+	public string Registration { get; } = registration;
+}

--- a/tests/Immediate.Apis.FunctionalTests/Features/WeatherForecast/Get.cs
+++ b/tests/Immediate.Apis.FunctionalTests/Features/WeatherForecast/Get.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 namespace Immediate.Apis.FunctionalTests.Features.WeatherForecast;
 
 [Handler]
-[MapGet("/forecast")]
+[MapGet("/forecast/{id:int}")]
 [AllowAnonymous]
 public static partial class Get
 {
@@ -13,7 +13,11 @@ public static partial class Get
 		=> endpoint
 			.WithDescription("Gets the current weather forecast");
 
-	public sealed record Query;
+	public sealed record Query
+	{
+		public required int Id { get; init; }
+		public required string Filter { get; init; }
+	}
 
 	public sealed record Result
 	{

--- a/tests/Immediate.Apis.FunctionalTests/Features/WeatherForecast/Put.cs
+++ b/tests/Immediate.Apis.FunctionalTests/Features/WeatherForecast/Put.cs
@@ -5,10 +5,11 @@ using Microsoft.AspNetCore.Authorization;
 namespace Immediate.Apis.FunctionalTests.Features.WeatherForecast;
 
 [Handler]
-[MapPut("/forecast")]
+[MapPut("/forecast/{date:datetime}")]
 [Authorize("Test")]
 public static partial class Put
 {
+	[EndpointRegistrationOverride(EndpointRegistration.AsParameters)]
 	public sealed record Command
 	{
 		public required DateOnly Date { get; init; }

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAllowAnonymousTests.MapMethodWithAllowAnonymousTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeConstructorTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithAuthorizeNamedPolicyArgumentTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ApiAuthorizeTests.MapMethodWithSimpleAuthorizeTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/CustomizeEndpointsTests.MapMethodCustomizeEndpointTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapDelete(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapGet(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPatch(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPost(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPut(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.AsParametersTest_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapDelete(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapGet(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPatch(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPost(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPut(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromBodyTest_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapDelete(
+				"/test",
+				async (
+					[FromForm] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapGet(
+				"/test",
+				async (
+					[FromForm] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPatch(
+				"/test",
+				async (
+					[FromForm] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPost(
+				"/test",
+				async (
+					[FromForm] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPut(
+				"/test",
+				async (
+					[FromForm] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromFormTest_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapDelete(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapGet(
+				"/test",
+				async (
+					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPatch(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPost(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPut(
+				"/test",
+				async (
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromHeaderTest_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapDelete(
+				"/test",
+				async (
+					[FromQuery] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapGet(
+				"/test",
+				async (
+					[FromQuery] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPatch(
+				"/test",
+				async (
+					[FromQuery] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPost(
+				"/test",
+				async (
+					[FromQuery] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPut(
+				"/test",
+				async (
+					[FromQuery] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromQueryTest_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapDelete(
+				"/test",
+				async (
+					[FromRoute] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Delete#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Delete#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapGet(
+				"/test",
+				async (
+					[FromRoute] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Get#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Get#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPatch(
+				"/test",
+				async (
+					[FromRoute] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Patch#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Patch#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPost(
+				"/test",
+				async (
+					[FromRoute] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Post#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Post#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	private static void MapDummy_GetUsersQueryEndpoint(IEndpointRouteBuilder app)
+	{
+		var endpoint = app
+			.MapPut(
+				"/test",
+				async (
+					[FromRoute] global::Dummy.GetUsersQuery.Query parameters,
+					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
+					CancellationToken token
+				) =>
+				{
+					var ret = await handler.HandleAsync(parameters, token);
+					return ret;
+				}
+			);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Put#RoutesBuilder.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.FromRouteTest_method=Put#RoutesBuilder.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: RoutesBuilder.g.cs
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable CS1591
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class TestsRoutesBuilder
+{
+	public static IEndpointRouteBuilder MapTestsEndpoints(
+		this IEndpointRouteBuilder app
+	)
+	{
+		MapDummy_GetUsersQueryEndpoint(app);
+
+		return app;
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/ParameterAttributeTests.cs
@@ -1,0 +1,226 @@
+namespace Immediate.Apis.Tests.GeneratorTests;
+
+public sealed class ParameterAttributeTests
+{
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task AsParametersTest(string method)
+	{
+		var driver = GeneratorTestHelper.GetDriver(
+			$$"""
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static class GetUsersQuery
+			{
+				[EndpointRegistrationOverride(EndpointRegistration.AsParameters)]
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 0;
+				}
+			}
+			""");
+
+		var result = driver.GetRunResult();
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(2, result.GeneratedTrees.Length);
+
+		_ = await Verify(result)
+			.UseParameters(method);
+	}
+
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task FromBodyTest(string method)
+	{
+		var driver = GeneratorTestHelper.GetDriver(
+			$$"""
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static class GetUsersQuery
+			{
+				[EndpointRegistrationOverride(EndpointRegistration.FromBody)]
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 0;
+				}
+			}
+			""");
+
+		var result = driver.GetRunResult();
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(2, result.GeneratedTrees.Length);
+
+		_ = await Verify(result)
+			.UseParameters(method);
+	}
+
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task FromFormTest(string method)
+	{
+		var driver = GeneratorTestHelper.GetDriver(
+			$$"""
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static class GetUsersQuery
+			{
+				[EndpointRegistrationOverride(EndpointRegistration.FromForm)]
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 0;
+				}
+			}
+			""");
+
+		var result = driver.GetRunResult();
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(2, result.GeneratedTrees.Length);
+
+		_ = await Verify(result)
+			.UseParameters(method);
+	}
+
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task FromHeaderTest(string method)
+	{
+		var driver = GeneratorTestHelper.GetDriver(
+			$$"""
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static class GetUsersQuery
+			{
+				[EndpointRegistrationOverride(EndpointRegistration.FromHeaders)]
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 0;
+				}
+			}
+			""");
+
+		var result = driver.GetRunResult();
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(2, result.GeneratedTrees.Length);
+
+		_ = await Verify(result)
+			.UseParameters(method);
+	}
+
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task FromQueryTest(string method)
+	{
+		var driver = GeneratorTestHelper.GetDriver(
+			$$"""
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static class GetUsersQuery
+			{
+				[EndpointRegistrationOverride(EndpointRegistration.FromQuery)]
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 0;
+				}
+			}
+			""");
+
+		var result = driver.GetRunResult();
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(2, result.GeneratedTrees.Length);
+
+		_ = await Verify(result)
+			.UseParameters(method);
+	}
+
+	[Theory]
+	[MemberData(nameof(Utility.Methods), MemberType = typeof(Utility))]
+	public async Task FromRouteTest(string method)
+	{
+		var driver = GeneratorTestHelper.GetDriver(
+			$$"""
+			using System.Threading.Tasks;
+			using Immediate.Apis.Shared;
+			using Immediate.Handlers.Shared;
+			
+			namespace Dummy;
+
+			[Handler]
+			[Map{{method}}("/test")]
+			public static class GetUsersQuery
+			{
+				[EndpointRegistrationOverride(EndpointRegistration.FromRoute)]
+				public record Query;
+
+				private static ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 0;
+				}
+			}
+			""");
+
+		var result = driver.GetRunResult();
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(2, result.GeneratedTrees.Length);
+
+		_ = await Verify(result)
+			.UseParameters(method);
+	}
+}

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleAsyncTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMethodHandleTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Delete#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Delete#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUserQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Get#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Get#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUserQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Patch#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Patch#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUserQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUserQuery.Query parameters,
+					[FromBody] global::Dummy.GetUserQuery.Query parameters,
 					[FromServices] global::Dummy.GetUserQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Post#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Post#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUserQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUserQuery.Query parameters,
+					[FromBody] global::Dummy.GetUserQuery.Query parameters,
 					[FromServices] global::Dummy.GetUserQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Put#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Put#RouteBuilder.Dummy_GetUserQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUserQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUserQuery.Query parameters,
+					[FromBody] global::Dummy.GetUserQuery.Query parameters,
 					[FromServices] global::Dummy.GetUserQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/SimpleApiTests.MapMultipleHandlersTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Delete#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Get#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591

--- a/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Patch#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPatch(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Post#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPost(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>

--- a/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Apis.Tests/GeneratorTests/TransformResultTests.TransformTest_method=Put#RouteBuilder.Dummy_GetUsersQuery.g.verified.cs
@@ -1,4 +1,5 @@
 ﻿//HintName: RouteBuilder.Dummy_GetUsersQuery.g.cs
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 #pragma warning disable CS1591
@@ -13,7 +14,7 @@ public static partial class TestsRoutesBuilder
 			.MapPut(
 				"/test",
 				async (
-					[AsParameters] global::Dummy.GetUsersQuery.Query parameters,
+					[FromBody] global::Dummy.GetUsersQuery.Query parameters,
 					[FromServices] global::Dummy.GetUsersQuery.Handler handler,
 					CancellationToken token
 				) =>


### PR DESCRIPTION
* Change default parameter registration on `POST`/`PATCH`/`PUT` to use `[FromBody]`
* Add the ability to override default registration with a custom registration

Fixes #27 